### PR TITLE
feat: Add honeypot link detection and removal utility

### DIFF
--- a/paddock-parser-consolidated/paddock_parser/adapters/equibase.py
+++ b/paddock-parser-consolidated/paddock_parser/adapters/equibase.py
@@ -12,6 +12,7 @@ from ..fetching import resilient_get
 from ..normalizer import NormalizedRace, NormalizedRunner, canonical_track_key, canonical_race_key
 from ..sources import RawRaceDocument, register_adapter
 from ..config_manager import config_manager
+from ..utils import remove_honeypot_links
 
 print("--- [equibase.py] Module loaded ---", file=sys.stderr)
 
@@ -68,6 +69,7 @@ class EquibaseAdapter(BaseAdapterV3):
 
     def _parse_race_list(self, html_content: str) -> list[str]:
         soup = BeautifulSoup(html_content, "html.parser")
+        soup = remove_honeypot_links(soup)
         links = soup.select('a[href*="/static/entry/"][href*="USA-D.html"]')
 
         race_urls = {urljoin(self._base_url, a['href']) for a in links}

--- a/paddock-parser-consolidated/paddock_parser/adapters/greyhound_recorder.py
+++ b/paddock-parser-consolidated/paddock_parser/adapters/greyhound_recorder.py
@@ -10,6 +10,7 @@ from typing import Optional, List
 from ..sources import RawRaceDocument, FieldConfidence, RunnerDoc, register_adapter
 from ..fetching import resilient_get
 from ..normalizer import canonical_track_key, canonical_race_key, parse_hhmm_any, map_discipline, normalize_race_docs, NormalizedRace
+from ..utils import remove_honeypot_links
 from .base_v3 import BaseAdapterV3
 
 @register_adapter
@@ -45,6 +46,7 @@ class GreyhoundRecorderAdapter(BaseAdapterV3):
                 return []
 
             soup = BeautifulSoup(response.text, "html.parser")
+            soup = remove_honeypot_links(soup)
             return self._parse_races_from_html(soup)
         except Exception as e:
             logging.error(f"[{self.source_id}] Failed to fetch or parse race list: {e}", exc_info=True)

--- a/paddock-parser-consolidated/paddock_parser/adapters/racingpost.py
+++ b/paddock-parser-consolidated/paddock_parser/adapters/racingpost.py
@@ -10,6 +10,7 @@ from typing import Optional, List
 from ..sources import RawRaceDocument, FieldConfidence, RunnerDoc, register_adapter
 from ..fetching import resilient_get
 from ..normalizer import canonical_track_key, canonical_race_key, parse_hhmm_any, map_discipline, normalize_race_docs, NormalizedRace
+from ..utils import remove_honeypot_links
 from .base_v3 import BaseAdapterV3
 
 @register_adapter
@@ -45,6 +46,7 @@ class RacingPostAdapter(BaseAdapterV3):
                 return []
 
             soup = BeautifulSoup(response.text, "html.parser")
+            soup = remove_honeypot_links(soup)
             return self._parse_races_from_html(soup)
         except Exception as e:
             logging.error(f"[{self.source_id}] Failed to fetch or parse race list: {e}", exc_info=True)

--- a/paddock-parser-consolidated/paddock_parser/utils.py
+++ b/paddock-parser-consolidated/paddock_parser/utils.py
@@ -1,0 +1,28 @@
+import logging
+from bs4 import BeautifulSoup
+
+def remove_honeypot_links(soup: BeautifulSoup) -> BeautifulSoup:
+    """
+    Removes invisible "honeypot" links from a BeautifulSoup object.
+
+    This function targets links that are likely to be scraper traps by checking
+    for common CSS styles used to hide elements from view.
+
+    Args:
+        soup: A BeautifulSoup object containing the parsed HTML.
+
+    Returns:
+        A BeautifulSoup object with the honeypot links removed.
+    """
+    honeypot_selectors = [
+        'a[style*="display: none"]',
+        'a[style*="visibility: hidden"]',
+    ]
+
+    for selector in honeypot_selectors:
+        honeypots = soup.select(selector)
+        for honeypot in honeypots:
+            logging.info(f"Removing potential honeypot link: {honeypot.get('href', 'No href found')}")
+            honeypot.decompose()
+
+    return soup


### PR DESCRIPTION
This change introduces a new utility to detect and remove invisible "honeypot" links from HTML content before parsing. This is a proactive scraper defense mechanism designed to improve the long-term viability and stealth of the toolkit.

The new `remove_honeypot_links` function has been integrated into the following HTML-based adapters:
- `RacingPostAdapter`
- `EquibaseAdapter`
- `GreyhoundRecorderAdapter`