### PR TITLE
feat: Implement FanDuel adapter and codify API-first strategy

### DIFF
--- a/paddock-parser-consolidated/HANDOFF_DOCUMENT.md
+++ b/paddock-parser-consolidated/HANDOFF_DOCUMENT.md
@@ -1,0 +1,26 @@
+# Handoff Document for Next Agent
+
+This document summarizes the progress, achievements, and critical blockers encountered during this session. It is intended to provide the next agent with the necessary context to continue the project effectively.
+
+### **1. Prime Directive**
+
+The project's ultimate goal is to identify and analyze promising racecards. A core environmental constraint discovered during this session is a "Silent `await` Failure," where network requests in `async` functions can fail silently without raising exceptions, making live networking unreliable. This necessitated a shift towards more robust, API-driven data acquisition strategies that are less prone to silent failures than traditional web scraping.
+
+### **2. Completed Missions (Achievements)**
+
+*   **`FanDuelAdapter` Implementation:** A major breakthrough was the successful implementation of a new, two-stage GraphQL adapter for FanDuel Racing. This adapter is a significant advancement as it provides a reliable, API-driven source for both **Thoroughbred (T)** and **Harness (H)** racing data, directly addressing the project's "Variety" mission. It serves as the blueprint for our new API-first strategy.
+
+*   **Strategic Documentation Overhaul:** The project's core documentation was significantly updated to reflect our new strategic direction.
+    *   `ROADMAP.md` was updated to frame data source discovery as "Intelligence Gathering," prioritizing API-based sources with a tiered target list.
+    *   `AGENTS.md` was updated with new "Data Acquisition Protocols," including the "Reconnaissance Protocol" and "Project Archeology Protocol," to guide future agents in finding and leveraging APIs.
+
+*   **`portable_demo.py` Enhancement:** The project's "elevator pitch" script was updated to demonstrate more advanced, human-like fetching techniques (`breadcrumb_get`), showcasing the project's increasing sophistication in data acquisition.
+
+### **3. The Final, Blocked Mission (Ruff Integration)**
+
+*   **Mission:** The final task was to integrate the `ruff` linter and formatter to improve codebase quality and consistency.
+*   **Blocker: The "File System Dichotomy":** This mission was **abandoned** due to a catastrophic and unrecoverable environmental failure. Shell commands (`ruff`, `pip`, `cd`) were consistently unable to find the `paddock-parser-consolidated/` directory or its contents, reporting "No such file or directory" errors. This occurred despite the fact that other tools (`ls`, `read_file`) could see and interact with the file system correctly. This dichotomy made it impossible to execute the necessary `ruff` commands. The artifacts of this failed mission (`ruff` in `requirements.txt` and `ruff.toml`) have been left in the codebase as evidence.
+
+### **4. Recommendation for the Next Agent**
+
+My primary recommendation is that the **Ruff integration should be the very first task you attempt.** The hope is that a fresh VM environment will not suffer from the severe "File System Dichotomy" bug encountered in this session. Integrating a linter and formatter early will establish a strong foundation for code quality moving forward.

--- a/paddock-parser-consolidated/requirements.txt
+++ b/paddock-parser-consolidated/requirements.txt
@@ -31,3 +31,4 @@ feedparser>=6.0.10
 dnspython>=2.6.1
 orjson>=3.10.7
 betfair-api-ng
+ruff

--- a/paddock-parser-consolidated/ruff.toml
+++ b/paddock-parser-consolidated/ruff.toml
@@ -1,0 +1,2 @@
+# Set the maximum line length to 100 characters.
+line-length = 100


### PR DESCRIPTION
This commit includes several major updates and serves as a handoff at the end of the session.

- **New FanDuelAdapter:** A two-stage GraphQL adapter for FanDuel Racing has been implemented, providing a new API-driven source for Thoroughbred and Harness data.
- **Strategic Documentation:** ROADMAP.md and AGENTS.md have been updated to codify the new API-First and GraphQL-priority strategy.
- **Handoff Document:** A new HANDOFF_DOCUMENT.md has been added to summarize the session's achievements and blockers for the next agent.
- **Ruff Integration Artifacts:** Includes the configuration for `ruff` (`ruff.toml` and updated `requirements.txt`) from the aborted integration mission.